### PR TITLE
Add missing import to fix build

### DIFF
--- a/Assets/Scripts/System/Console/CommandManager.cs
+++ b/Assets/Scripts/System/Console/CommandManager.cs
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 
 /*
  * Registers, parses and executes commands.


### PR DESCRIPTION
The project runs fine in the Editor but fails to build because of a missing import. I fixed this here.

The code that was breaking (`CommandManager:145`):

```
#if UNITY_EDITOR
        UnityEditor.EditorApplication.isPlaying = false;
#else
        Console.LogWarning("pepehands");
        Application.Quit(); <-- here
#endif
```